### PR TITLE
fix: trigger animation on slide change for Reveal.js

### DIFF
--- a/_extensions/animate/animate-shortcodes.lua
+++ b/_extensions/animate/animate-shortcodes.lua
@@ -28,6 +28,12 @@ local function ensure_html_deps()
     version = '4.1.1',
     stylesheets = {"animate.min.css"}
   })
+  if quarto.doc.is_format("revealjs") then
+    quarto.doc.add_html_dependency({
+      name = "animatejs",
+      scripts = {{ path = "animate.js", afterBody = true }}
+    })
+  end
 end
 
 local function is_empty(s)

--- a/_extensions/animate/animate.js
+++ b/_extensions/animate/animate.js
@@ -1,0 +1,11 @@
+Reveal.addEventListener('slidechanged', function (event) {
+  const animatedElements = event.currentSlide.querySelectorAll('.animate__animated');
+  animatedElements.forEach(element => {
+    const animationClass = Array.from(element.classList).find(cls => cls.startsWith('animate__') && cls !== 'animate__animated');
+    if (animationClass) {
+      element.classList.remove(animationClass);
+      void element.offsetWidth;
+      element.classList.add(animationClass);
+    }
+  });
+});


### PR DESCRIPTION
Ensure animations are triggered when the slide changes in Reveal.js presentations. This fix addresses the issue of animations only starting on page load or reload. The necessary JavaScript has been added to handle animation classes dynamically during slide transitions. Fixes #5