### PR TITLE
feat: allow global animation options in Quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,29 @@ To animate a text, use the `{{< animate >}}` shortcode. For example:
 ```
 
 - Mandatory `<effect>` and `<text>`:
+
   ``` markdown
   {{< animate <effect> "<text>" >}}
   ```
 
 - Optional `<delay=...>`, `<duration=...>`, and `<repeat=...>`:
+
   ``` markdown
   {{< animate <effect> "<text>" <delay=...> <duration=...> <repeat=...> >}}
   ```
+
   `<delay=...>` and `<duration=...>` are durations requiring unit, _e.g._, `1s` or `800ms`.  
   See <https://animate.style/> for more details.
+
+Defining default values for animations can be done in the YAML front matter of your document:
+
+```yml
+extensions:
+  animate:
+    delay: 5s
+    duration: 10s
+    repeat: 3
+```
 
 ## Advanced
 

--- a/_extensions/animate/animate-shortcodes.lua
+++ b/_extensions/animate/animate-shortcodes.lua
@@ -22,20 +22,37 @@
 # SOFTWARE.
 ]]
 
+--- Pandoc utility function for converting values to strings
+--- @type function
+local stringify = pandoc.utils.stringify
+
 --- Check if a string is empty or nil.
--- @param s string|nil
--- @return boolean
+--- Utility function to determine if a value is empty or nil,
+--- which is useful for parameter validation throughout the module.
+--- @param s string|nil|table The value to check for emptiness
+--- @return boolean True if the value is nil or empty, false otherwise
+--- @usage local result = is_empty("") -- returns true
+--- @usage local result = is_empty(nil) -- returns true
+--- @usage local result = is_empty("hello") -- returns false
 local function is_empty(s)
   return s == nil or s == ''
 end
 
 --- Validate if the effect is a supported animation.
--- @param effect string|nil
--- @return string
+--- Checks if the provided animation effect is supported by the Animate.css library.
+--- Returns the formatted CSS classes if valid, or an empty string if invalid.
+--- @param effect string|nil The animation effect name to validate
+--- @return string The formatted CSS class string or empty string if invalid
+--- @usage local classes = is_valid_animation("bounce") -- returns "animate__animated animate__bounce"
+--- @usage local classes = is_valid_animation("invalid") -- returns ""
+--- @see https://animate.style/ For complete list of available animations
 local function is_valid_animation(effect)
   if is_empty(effect) then
     return ''
   end
+
+  --- Array of supported animation effects from Animate.css library
+  --- @type string[] List of all valid animation names
   local animation_array = {
     "bounce",
     "flash",
@@ -135,105 +152,160 @@ local function is_valid_animation(effect)
     "slideOutRight",
     "slideOutUp",
   }
+
+  -- Check if the provided effect matches any supported animation
   for _, value in ipairs(animation_array) do
     if value == effect then
       return 'animate__animated animate__' .. effect
     end
   end
+
+  -- Return empty string if animation is not supported
   return ''
 end
 
-local yamlAniDuration = "3s"
-local yamlAniDelay = "2s"
-local yamlAniRepeat = "1"
+--- Default animation options configuration
+--- @type table<string, string> Default values for animation properties
+local animate_options = {
+  ["duration"] = "3s", -- Default animation duration
+  ["delay"] = "2s",    -- Default animation delay before starting
+  ["repeat"] = "1"     -- Default number of animation repetitions
+}
 
---- Set animation options from meta.
--- @param meta table
--- @return table
-function setAniOptions(meta)
-  if not is_empty(meta['ani-delay']) then
-    yamlAniDelay = meta['ani-delay']
+--- Global variable to track if HTML dependencies have been added
+--- Prevents duplicate dependency injection in the document
+--- @type boolean Flag indicating whether HTML dependencies are already loaded
+local html_deps_added = false
+
+--- Get animate option from arguments or metadata.
+--- Retrieves animation configuration values with fallback hierarchy:
+--- 1. Document metadata values
+--- 2. Default values from animate_options
+--- @param x string The option key to retrieve (duration, delay, repeat)
+--- @param meta table|nil Document metadata containing animate configuration
+--- @param default table<string, string> Default options table to fall back to
+--- @return string The resolved option value
+--- @usage local duration = get_animate_options('duration', meta['animate'], animate_options)
+local function get_animate_options(x, meta, default)
+  if meta and meta[x] and not is_empty(meta[x]) then
+    return stringify(meta[x])
   end
-  if not is_empty(meta['ani-duration']) then
-    yamlAniDuration = meta['ani-duration']
-  end
-  if not is_empty(meta['ani-repeat']) then
-    yamlAniRepeat = meta['ani-repeat']
-  end
-  meta['ani-delay'] = yamlAniDelay
-  meta['ani-duration'] = yamlAniDuration
-  meta['ani-repeat'] = yamlAniRepeat
-  return meta
+  return default[x]
 end
 
 --- Ensure HTML dependencies for animate are added.
--- @return nil
-local function ensure_html_deps()
+--- Adds the necessary CSS and JavaScript dependencies for animations to work.
+--- Only adds dependencies once per document to avoid duplication.
+--- Handles both regular HTML output and RevealJS presentations.
+--- @param options table<string, string> Animation options containing duration, delay, and repeat values
+--- @return nil This function doesn't return a value, it modifies the document
+--- @usage ensure_html_deps({duration = "2s", delay = "1s", repeat = "3"})
+local function ensure_html_deps(options)
+  -- Exit early if dependencies are already added
+  if html_deps_added then
+    return
+  end
+
+  -- Add core Animate.css stylesheet and CSS custom properties
   quarto.doc.add_html_dependency({
     name = 'animate',
     version = '4.1.1',
-    stylesheets = {"animate.min.css"},
-    head = "<style>:root{--animate-duration:" .. yamlAniDuration ..
-      ";--animate-delay:" .. yamlAniDelay .. ";--animate-repeat:" .. yamlAniRepeat .. "}</style>"
+    stylesheets = { "animate.min.css" },
+    head = "<style>:root{--animate-duration:" .. options['duration'] ..
+        ";--animate-delay:" .. options['delay'] ..
+        ";--animate-repeat:" .. options['repeat'] .. "}</style>"
   })
+
+  -- Add additional JavaScript for RevealJS presentations
   if quarto.doc.is_format("revealjs") then
     quarto.doc.add_html_dependency({
       name = "animatejs",
-      scripts = {{ path = "animate.js", afterBody = true }}
+      scripts = { { path = "animate.js", afterBody = true } }
     })
   end
+
+  -- Mark dependencies as added to prevent duplication
+  html_deps_added = true
 end
 
 --- Animate shortcode handler.
--- @param args table
--- @param kwargs table
--- @return pandoc.Inline|pandoc.Null
-function animate(args, kwargs)
-  -- detect html (excluding epub which won't handle fa)
+--- Main function that processes the animate shortcode and generates the appropriate HTML output.
+--- Handles parameter parsing, validation, and HTML generation for animated elements.
+--- Only generates output for HTML-based formats; returns null for other formats.
+---
+--- Supported parameters:
+--- - args[1]: Animation type (e.g., "bounce", "fadeIn", "slideUp")
+--- - args[2]: Content to animate
+--- - kwargs.delay: Custom delay override (e.g., "1s", "500ms")
+--- - kwargs.duration: Custom duration override (e.g., "2s", "1500ms")
+--- - kwargs.repeat: Custom repeat count override (e.g., "3", "infinite")
+---
+--- @param args table Array of positional arguments from the shortcode
+--- @param kwargs table Table of named keyword arguments from the shortcode
+--- @param meta table Document metadata that may contain global animate settings
+--- @return pandoc.RawInline|nil HTML span element with animation classes or null for non-HTML formats
+--- @usage {{< animate bounce delay=1s >}}Hello World{{< /animate >}}
+--- @usage {{< animate fadeIn duration=3s repeat=infinite >}}Animated text{{< /animate >}}
+function animate(args, kwargs, meta)
+  -- Only process for HTML-based formats (excluding epub which won't handle animations)
   if quarto.doc.is_format("html:js") then
-    ensure_html_deps()
+    -- Build options table with fallbacks to metadata or defaults
+    local options = {
+      ["duration"] = get_animate_options('duration', meta and meta['animate'] or nil, animate_options),
+      ["delay"] = get_animate_options('delay', meta and meta['animate'] or nil, animate_options),
+      ["repeat"] = get_animate_options('repeat', meta and meta['animate'] or nil, animate_options)
+    }
 
-    local animation = is_valid_animation(pandoc.utils.stringify(args[1]))
+    -- Ensure required dependencies are loaded
+    ensure_html_deps(options)
+
+    -- Validate and get animation CSS classes
+    local animation = is_valid_animation(stringify(args[1]))
     if is_empty(animation) then
       return pandoc.Null()
     end
 
-    local aniDelay = pandoc.utils.stringify(kwargs["delay"])
-    if is_empty(aniDelay) then
-      attr_delay = ''
+    -- Process delay parameter with fallback to options
+    local animate_delay = stringify(kwargs["delay"]) or options['delay']
+    if is_empty(animate_delay) then
+      animate_delay = options['delay']
+    end
+    local attr_delay = ' animate__delay-' .. animate_delay
+
+    -- Process repeat parameter with fallback to options
+    local animate_repeat = stringify(kwargs["repeat"])
+    if is_empty(animate_repeat) then
+      animate_repeat = options['repeat']
+    end
+    local attr_repeat = ''
+    if (animate_repeat == "infinite") then
+      attr_repeat = ' animate__' .. animate_repeat
     else
-      attr_delay = ' animate__delay-' .. aniDelay
+      attr_repeat = ' animate__repeat-' .. animate_repeat
     end
 
-    local aniRepeat = pandoc.utils.stringify(kwargs["repeat"])
-    if is_empty(aniRepeat) then
-      attr_repeat = ''
-    else
-      if (aniRepeat == "infinite") then
-        attr_repeat = ' animate__' .. aniRepeat
-      else
-        attr_repeat = ' animate__repeat-' .. aniRepeat
-      end
+    -- Process duration parameter with fallback to options
+    local animate_duration = stringify(kwargs["duration"]) or options['duration']
+    if is_empty(animate_duration) then
+      animate_duration = options['duration']
     end
+    local attr_duration = 'style="display: inline-block;animation-duration:' .. animate_duration .. '"'
 
-    local aniDuration = pandoc.utils.stringify(kwargs["duration"])
-    if is_empty(aniDuration) then
-      attr_duration = 'style="display: inline-block;"'
-    else
-      attr_duration = 'style="display: inline-block;animation-duration:' .. aniDuration .. '"'
-    end
-
+    -- Generate and return the animated HTML span element
     return pandoc.RawInline(
       'html',
       '<span class="' .. animation .. attr_delay .. attr_repeat .. '" ' ..
-        attr_duration .. '>' .. pandoc.utils.stringify(args[2]) .. '</span>'
+      attr_duration .. '>' .. stringify(args[2]) .. '</span>'
     )
   else
+    -- Return null for non-HTML formats
     return pandoc.Null()
   end
 end
 
+--- Module export table
+--- Defines the shortcodes available to Quarto for processing
+--- @type table<string, function> Table mapping shortcode names to handler functions
 return {
-  {Meta = setAniOptions},
   ["animate"] = animate
 }

--- a/example.qmd
+++ b/example.qmd
@@ -1,8 +1,12 @@
 ---
 title: 'Animate.css Extension for Quarto'
 format: html
+extensions:
+  animate:
+    delay: 5s
+    duration: 10s
+    repeat: 3
 ---
-
 
 ## Using the extension
 
@@ -11,14 +15,17 @@ Animations are only available for HTML-based documents.
 It provides an `{{{< animate >}}}` shortcode:
 
 - Mandatory `<effect>` and `<text>`:
-  ``` markdown
+
+  ```markdown
   {{{< animate <effect> "<text>" >}}}
   ```
 
 - Optional `<delay=...>`, `<duration=...>`, and `<repeat=...>`:
-  ``` markdown
+
+  ```markdown
   {{{< animate <effect> "<text>" <delay=...> <duration=...> <repeat=...> >}}}
   ```
+
   `<delay=...>` and `<duration=...>` are durations requiring unit, _e.g._, `1s` or `800ms`.  
   See <https://animate.style/> for more details.
 
@@ -29,6 +36,16 @@ For example:
 | `{{{< animate bounce "Some text" >}}}`                                     | {{< animate bounce "Some text" >}}                                     |
 | `{{{< animate flip "Some text" repeat=2 >}}}`                              | {{< animate flip "Some text" repeat=2 >}}                              |
 | `{{{< animate hinge "Some text" delay=3s duration=4s repeat=infinite >}}}` | {{< animate hinge "Some text" delay=1s duration=2s repeat=infinite >}} |
+
+Defining default values for animations can be done in the YAML front matter of your document:
+
+```yml
+extensions:
+  animate:
+    delay: 5s
+    duration: 10s
+    repeat: 3
+```
 
 ## Advanced
 
@@ -62,145 +79,145 @@ Or:
 
 ### Attention seekers
 
-- `bounce` {{< animate bounce "bounce" repeat=infinite duration=4s >}}
-- `flash` {{< animate flash "flash" repeat=infinite duration=4s >}}
-- `pulse` {{< animate pulse "pulse" repeat=infinite duration=4s >}}
-- `rubberBand` {{< animate rubberBand "rubberBand" repeat=infinite duration=4s >}}
-- `shakeX` {{< animate shakeX "shakeX" repeat=infinite duration=4s >}}
-- `shakeY` {{< animate shakeY "shakeY" repeat=infinite duration=4s >}}
-- `headShake` {{< animate headShake "headShake" repeat=infinite duration=4s >}}
-- `swing` {{< animate swing "swing" repeat=infinite duration=4s >}}
-- `tada` {{< animate tada "tada" repeat=infinite duration=4s >}}
-- `wobble` {{< animate wobble "wobble" repeat=infinite duration=4s >}}
-- `jello` {{< animate jello "jello" repeat=infinite duration=4s >}}
-- `heartBeat` {{< animate heartBeat "heartBeat" repeat=infinite duration=4s >}}
+- `bounce` {{< animate bounce "bounce" >}}
+- `flash` {{< animate flash "flash" >}}
+- `pulse` {{< animate pulse "pulse" >}}
+- `rubberBand` {{< animate rubberBand "rubberBand" >}}
+- `shakeX` {{< animate shakeX "shakeX" >}}
+- `shakeY` {{< animate shakeY "shakeY" >}}
+- `headShake` {{< animate headShake "headShake" >}}
+- `swing` {{< animate swing "swing" >}}
+- `tada` {{< animate tada "tada" >}}
+- `wobble` {{< animate wobble "wobble" >}}
+- `jello` {{< animate jello "jello" >}}
+- `heartBeat` {{< animate heartBeat "heartBeat" >}}
 
 ### Back entrances
 
-- `backInDown` {{< animate backInDown "backInDown" repeat=infinite duration=4s >}}
-- `backInLeft` {{< animate backInLeft "backInLeft" repeat=infinite duration=4s >}}
-- `backInRight` {{< animate backInRight "backInRight" repeat=infinite duration=4s >}}
-- `backInUp` {{< animate backInUp "backInUp" repeat=infinite duration=4s >}}
+- `backInDown` {{< animate backInDown "backInDown" >}}
+- `backInLeft` {{< animate backInLeft "backInLeft" >}}
+- `backInRight` {{< animate backInRight "backInRight" >}}
+- `backInUp` {{< animate backInUp "backInUp" >}}
 
 ### Back exits
 
-- `backOutDown` {{< animate backOutDown "backOutDown" repeat=infinite duration=4s >}}
-- `backOutLeft` {{< animate backOutLeft "backOutLeft" repeat=infinite duration=4s >}}
-- `backOutRight` {{< animate backOutRight "backOutRight" repeat=infinite duration=4s >}}
-- `backOutUp` {{< animate backOutUp "backOutUp" repeat=infinite duration=4s >}}
+- `backOutDown` {{< animate backOutDown "backOutDown" >}}
+- `backOutLeft` {{< animate backOutLeft "backOutLeft" >}}
+- `backOutRight` {{< animate backOutRight "backOutRight" >}}
+- `backOutUp` {{< animate backOutUp "backOutUp" >}}
 
 ### Bouncing entrances
 
-- `bounceIn` {{< animate bounceIn "bounceIn" repeat=infinite duration=4s >}}
-- `bounceInDown` {{< animate bounceInDown "bounceInDown" repeat=infinite duration=4s >}}
-- `bounceInLeft` {{< animate bounceInLeft "bounceInLeft" repeat=infinite duration=4s >}}
-- `bounceInRight` {{< animate bounceInRight "bounceInRight" repeat=infinite duration=4s >}}
-- `bounceInUp` {{< animate bounceInUp "bounceInUp" repeat=infinite duration=4s >}}
+- `bounceIn` {{< animate bounceIn "bounceIn" >}}
+- `bounceInDown` {{< animate bounceInDown "bounceInDown" >}}
+- `bounceInLeft` {{< animate bounceInLeft "bounceInLeft" >}}
+- `bounceInRight` {{< animate bounceInRight "bounceInRight" >}}
+- `bounceInUp` {{< animate bounceInUp "bounceInUp" >}}
 
 ### Bouncing exits
 
-- `bounceOut` {{< animate bounceOut "bounceOut" repeat=infinite duration=4s >}}
-- `bounceOutDown` {{< animate bounceOutDown "bounceOutDown" repeat=infinite duration=4s >}}
-- `bounceOutLeft` {{< animate bounceOutLeft "bounceOutLeft" repeat=infinite duration=4s >}}
-- `bounceOutRight` {{< animate bounceOutRight "bounceOutRight" repeat=infinite duration=4s >}}
-- `bounceOutUp` {{< animate bounceOutUp "bounceOutUp" repeat=infinite duration=4s >}}
+- `bounceOut` {{< animate bounceOut "bounceOut" >}}
+- `bounceOutDown` {{< animate bounceOutDown "bounceOutDown" >}}
+- `bounceOutLeft` {{< animate bounceOutLeft "bounceOutLeft" >}}
+- `bounceOutRight` {{< animate bounceOutRight "bounceOutRight" >}}
+- `bounceOutUp` {{< animate bounceOutUp "bounceOutUp" >}}
 
 ### Fading entrances
 
-- `fadeIn` {{< animate fadeIn "fadeIn" repeat=infinite duration=4s >}}
-- `fadeInDown` {{< animate fadeInDown "fadeInDown" repeat=infinite duration=4s >}}
-- `fadeInDownBig` {{< animate fadeInDownBig "fadeInDownBig" repeat=infinite duration=4s >}}
-- `fadeInLeft` {{< animate fadeInLeft "fadeInLeft" repeat=infinite duration=4s >}}
-- `fadeInLeftBig` {{< animate fadeInLeftBig "fadeInLeftBig" repeat=infinite duration=4s >}}
-- `fadeInRight` {{< animate fadeInRight "fadeInRight" repeat=infinite duration=4s >}}
-- `fadeInRightBig` {{< animate fadeInRightBig "fadeInRightBig" repeat=infinite duration=4s >}}
-- `fadeInUp` {{< animate fadeInUp "fadeInUp" repeat=infinite duration=4s >}}
-- `fadeInUpBig` {{< animate fadeInUpBig "fadeInUpBig" repeat=infinite duration=4s >}}
-- `fadeInTopLeft` {{< animate fadeInTopLeft "fadeInTopLeft" repeat=infinite duration=4s >}}
-- `fadeInTopRight` {{< animate fadeInTopRight "fadeInTopRight" repeat=infinite duration=4s >}}
-- `fadeInBottomLeft` {{< animate fadeInBottomLeft "fadeInBottomLeft" repeat=infinite duration=4s >}}
-- `fadeInBottomRight` {{< animate fadeInBottomRight "fadeInBottomRight" repeat=infinite duration=4s >}}
+- `fadeIn` {{< animate fadeIn "fadeIn" >}}
+- `fadeInDown` {{< animate fadeInDown "fadeInDown" >}}
+- `fadeInDownBig` {{< animate fadeInDownBig "fadeInDownBig" >}}
+- `fadeInLeft` {{< animate fadeInLeft "fadeInLeft" >}}
+- `fadeInLeftBig` {{< animate fadeInLeftBig "fadeInLeftBig" >}}
+- `fadeInRight` {{< animate fadeInRight "fadeInRight" >}}
+- `fadeInRightBig` {{< animate fadeInRightBig "fadeInRightBig" >}}
+- `fadeInUp` {{< animate fadeInUp "fadeInUp" >}}
+- `fadeInUpBig` {{< animate fadeInUpBig "fadeInUpBig" >}}
+- `fadeInTopLeft` {{< animate fadeInTopLeft "fadeInTopLeft" >}}
+- `fadeInTopRight` {{< animate fadeInTopRight "fadeInTopRight" >}}
+- `fadeInBottomLeft` {{< animate fadeInBottomLeft "fadeInBottomLeft" >}}
+- `fadeInBottomRight` {{< animate fadeInBottomRight "fadeInBottomRight" >}}
 
 ### Fading exits
 
-- `fadeOut` {{< animate fadeOut "fadeOut" repeat=infinite duration=4s >}}
-- `fadeOutDown` {{< animate fadeOutDown "fadeOutDown" repeat=infinite duration=4s >}}
-- `fadeOutDownBig` {{< animate fadeOutDownBig "fadeOutDownBig" repeat=infinite duration=4s >}}
-- `fadeOutLeft` {{< animate fadeOutLeft "fadeOutLeft" repeat=infinite duration=4s >}}
-- `fadeOutLeftBig` {{< animate fadeOutLeftBig "fadeOutLeftBig" repeat=infinite duration=4s >}}
-- `fadeOutRight` {{< animate fadeOutRight "fadeOutRight" repeat=infinite duration=4s >}}
-- `fadeOutRightBig` {{< animate fadeOutRightBig "fadeOutRightBig" repeat=infinite duration=4s >}}
-- `fadeOutUp` {{< animate fadeOutUp "fadeOutUp" repeat=infinite duration=4s >}}
-- `fadeOutUpBig` {{< animate fadeOutUpBig "fadeOutUpBig" repeat=infinite duration=4s >}}
-- `fadeOutTopLeft` {{< animate fadeOutTopLeft "fadeOutTopLeft" repeat=infinite duration=4s >}}
-- `fadeOutTopRight` {{< animate fadeOutTopRight "fadeOutTopRight" repeat=infinite duration=4s >}}
-- `fadeOutBottomRight` {{< animate fadeOutBottomRight "fadeOutBottomRight" repeat=infinite duration=4s >}}
-- `fadeOutBottomLeft` {{< animate fadeOutBottomLeft "fadeOutBottomLeft" repeat=infinite duration=4s >}}
+- `fadeOut` {{< animate fadeOut "fadeOut" >}}
+- `fadeOutDown` {{< animate fadeOutDown "fadeOutDown" >}}
+- `fadeOutDownBig` {{< animate fadeOutDownBig "fadeOutDownBig" >}}
+- `fadeOutLeft` {{< animate fadeOutLeft "fadeOutLeft" >}}
+- `fadeOutLeftBig` {{< animate fadeOutLeftBig "fadeOutLeftBig" >}}
+- `fadeOutRight` {{< animate fadeOutRight "fadeOutRight" >}}
+- `fadeOutRightBig` {{< animate fadeOutRightBig "fadeOutRightBig" >}}
+- `fadeOutUp` {{< animate fadeOutUp "fadeOutUp" >}}
+- `fadeOutUpBig` {{< animate fadeOutUpBig "fadeOutUpBig" >}}
+- `fadeOutTopLeft` {{< animate fadeOutTopLeft "fadeOutTopLeft" >}}
+- `fadeOutTopRight` {{< animate fadeOutTopRight "fadeOutTopRight" >}}
+- `fadeOutBottomRight` {{< animate fadeOutBottomRight "fadeOutBottomRight" >}}
+- `fadeOutBottomLeft` {{< animate fadeOutBottomLeft "fadeOutBottomLeft" >}}
 
 ### Flippers
 
-- `flip` {{< animate flip "flip" repeat=infinite duration=4s >}}
-- `flipInX` {{< animate flipInX "flipInX" repeat=infinite duration=4s >}}
-- `flipInY` {{< animate flipInY "flipInY" repeat=infinite duration=4s >}}
-- `flipOutX` {{< animate flipOutX "flipOutX" repeat=infinite duration=4s >}}
-- `flipOutY` {{< animate flipOutY "flipOutY" repeat=infinite duration=4s >}}
+- `flip` {{< animate flip "flip" >}}
+- `flipInX` {{< animate flipInX "flipInX" >}}
+- `flipInY` {{< animate flipInY "flipInY" >}}
+- `flipOutX` {{< animate flipOutX "flipOutX" >}}
+- `flipOutY` {{< animate flipOutY "flipOutY" >}}
 
 ### Lightspeed
 
-- `lightSpeedInRight` {{< animate lightSpeedInRight "lightSpeedInRight" repeat=infinite duration=4s >}}
-- `lightSpeedInLeft` {{< animate lightSpeedInLeft "lightSpeedInLeft" repeat=infinite duration=4s >}}
-- `lightSpeedOutRight` {{< animate lightSpeedOutRight "lightSpeedOutRight" repeat=infinite duration=4s >}}
-- `lightSpeedOutLeft` {{< animate lightSpeedOutLeft "lightSpeedOutLeft" repeat=infinite duration=4s >}}
+- `lightSpeedInRight` {{< animate lightSpeedInRight "lightSpeedInRight" >}}
+- `lightSpeedInLeft` {{< animate lightSpeedInLeft "lightSpeedInLeft" >}}
+- `lightSpeedOutRight` {{< animate lightSpeedOutRight "lightSpeedOutRight" >}}
+- `lightSpeedOutLeft` {{< animate lightSpeedOutLeft "lightSpeedOutLeft" >}}
 
 ### Rotating entrances
 
-- `rotateIn` {{< animate rotateIn "rotateIn" repeat=infinite duration=4s >}}
-- `rotateInDownLeft` {{< animate rotateInDownLeft "rotateInDownLeft" repeat=infinite duration=4s >}}
-- `rotateInDownRight` {{< animate rotateInDownRight "rotateInDownRight" repeat=infinite duration=4s >}}
-- `rotateInUpLeft` {{< animate rotateInUpLeft "rotateInUpLeft" repeat=infinite duration=4s >}}
-- `rotateInUpRight` {{< animate rotateInUpRight "rotateInUpRight" repeat=infinite duration=4s >}}
+- `rotateIn` {{< animate rotateIn "rotateIn" >}}
+- `rotateInDownLeft` {{< animate rotateInDownLeft "rotateInDownLeft" >}}
+- `rotateInDownRight` {{< animate rotateInDownRight "rotateInDownRight" >}}
+- `rotateInUpLeft` {{< animate rotateInUpLeft "rotateInUpLeft" >}}
+- `rotateInUpRight` {{< animate rotateInUpRight "rotateInUpRight" >}}
 
 ### Rotating exits
 
-- `rotateOut` {{< animate rotateOut "rotateOut" repeat=infinite duration=4s >}}
-- `rotateOutDownLeft` {{< animate rotateOutDownLeft "rotateOutDownLeft" repeat=infinite duration=4s >}}
-- `rotateOutDownRight` {{< animate rotateOutDownRight "rotateOutDownRight" repeat=infinite duration=4s >}}
-- `rotateOutUpLeft` {{< animate rotateOutUpLeft "rotateOutUpLeft" repeat=infinite duration=4s >}}
-- `rotateOutUpRight` {{< animate rotateOutUpRight "rotateOutUpRight" repeat=infinite duration=4s >}}
+- `rotateOut` {{< animate rotateOut "rotateOut" >}}
+- `rotateOutDownLeft` {{< animate rotateOutDownLeft "rotateOutDownLeft" >}}
+- `rotateOutDownRight` {{< animate rotateOutDownRight "rotateOutDownRight" >}}
+- `rotateOutUpLeft` {{< animate rotateOutUpLeft "rotateOutUpLeft" >}}
+- `rotateOutUpRight` {{< animate rotateOutUpRight "rotateOutUpRight" >}}
 
 ### Specials
 
-- `hinge` {{< animate hinge "hinge" repeat=infinite duration=4s >}}
-- `jackInTheBox` {{< animate jackInTheBox "jackInTheBox" repeat=infinite duration=4s >}}
-- `rollIn` {{< animate rollIn "rollIn" repeat=infinite duration=4s >}}
-- `rollOut` {{< animate rollOut "rollOut" repeat=infinite duration=4s >}}
+- `hinge` {{< animate hinge "hinge" >}}
+- `jackInTheBox` {{< animate jackInTheBox "jackInTheBox" >}}
+- `rollIn` {{< animate rollIn "rollIn" >}}
+- `rollOut` {{< animate rollOut "rollOut" >}}
 
 ### Zooming entrances
 
-- `zoomIn` {{< animate zoomIn "zoomIn" repeat=infinite duration=4s >}}
-- `zoomInDown` {{< animate zoomInDown "zoomInDown" repeat=infinite duration=4s >}}
-- `zoomInLeft` {{< animate zoomInLeft "zoomInLeft" repeat=infinite duration=4s >}}
-- `zoomInRight` {{< animate zoomInRight "zoomInRight" repeat=infinite duration=4s >}}
-- `zoomInUp` {{< animate zoomInUp "zoomInUp" repeat=infinite duration=4s >}}
+- `zoomIn` {{< animate zoomIn "zoomIn" >}}
+- `zoomInDown` {{< animate zoomInDown "zoomInDown" >}}
+- `zoomInLeft` {{< animate zoomInLeft "zoomInLeft" >}}
+- `zoomInRight` {{< animate zoomInRight "zoomInRight" >}}
+- `zoomInUp` {{< animate zoomInUp "zoomInUp" >}}
 
 ### Zooming exits
 
-- `zoomOut` {{< animate zoomOut "zoomOut" repeat=infinite duration=4s >}}
-- `zoomOutDown` {{< animate zoomOutDown "zoomOutDown" repeat=infinite duration=4s >}}
-- `zoomOutLeft` {{< animate zoomOutLeft "zoomOutLeft" repeat=infinite duration=4s >}}
-- `zoomOutRight` {{< animate zoomOutRight "zoomOutRight" repeat=infinite duration=4s >}}
-- `zoomOutUp` {{< animate zoomOutUp "zoomOutUp" repeat=infinite duration=4s >}}
+- `zoomOut` {{< animate zoomOut "zoomOut" >}}
+- `zoomOutDown` {{< animate zoomOutDown "zoomOutDown" >}}
+- `zoomOutLeft` {{< animate zoomOutLeft "zoomOutLeft" >}}
+- `zoomOutRight` {{< animate zoomOutRight "zoomOutRight" >}}
+- `zoomOutUp` {{< animate zoomOutUp "zoomOutUp" >}}
 
 ### Sliding entrances
 
-- `slideInDown` {{< animate slideInDown "slideInDown" repeat=infinite duration=4s >}}
-- `slideInLeft` {{< animate slideInLeft "slideInLeft" repeat=infinite duration=4s >}}
-- `slideInRight` {{< animate slideInRight "slideInRight" repeat=infinite duration=4s >}}
-- `slideInUp` {{< animate slideInUp "slideInUp" repeat=infinite duration=4s >}}
+- `slideInDown` {{< animate slideInDown "slideInDown" >}}
+- `slideInLeft` {{< animate slideInLeft "slideInLeft" >}}
+- `slideInRight` {{< animate slideInRight "slideInRight" >}}
+- `slideInUp` {{< animate slideInUp "slideInUp" >}}
 
 ### Sliding exits
 
-- `slideOutDown` {{< animate slideOutDown "slideOutDown" repeat=infinite duration=4s >}}
-- `slideOutLeft` {{< animate slideOutLeft "slideOutLeft" repeat=infinite duration=4s >}}
-- `slideOutRight` {{< animate slideOutRight "slideOutRight" repeat=infinite duration=4s >}}
-- `slideOutUp` {{< animate slideOutUp "slideOutUp" repeat=infinite duration=4s >}}
+- `slideOutDown` {{< animate slideOutDown "slideOutDown" >}}
+- `slideOutLeft` {{< animate slideOutLeft "slideOutLeft" >}}
+- `slideOutRight` {{< animate slideOutRight "slideOutRight" >}}
+- `slideOutUp` {{< animate slideOutUp "slideOutUp" >}}


### PR DESCRIPTION
Introduce the ability to define default animation settings in the YAML front matter, enabling users to set global values for delay, duration, and repeat for animations. This enhances flexibility and consistency across documents.