### PR TITLE
feat: add stagger and direction attributes, escape HTML, validate options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 1.7.0 (2026-05-28)
+
+### New Features
+
+- feat: Add `stagger` attribute to offset sequential animations by an incremental delay.
+- feat: Add `direction` attribute mapping to CSS `animation-direction` (`normal`, `reverse`, `alternate`, `alternate-reverse`).
+
+### Bug Fixes
+
+- fix: Escape HTML special characters in animated text so quotes, ampersands, and angle brackets render correctly.
+- fix: Validate `duration`, `delay`, `repeat`, `stagger`, and `direction` values; emit a warning and fall back to defaults on invalid input.
+- fix: Warn when an unknown animation effect is requested instead of failing silently.
+- fix: Reset module-level state on document boundaries to avoid bleed across batch renders.
+
+### Documentation
+
+- docs: Document `stagger`, `direction`, and automatic HTML escaping in the README and example.
+- docs: Extend `_schema.yml` and `_snippets.json` with the new attributes.
+
 ## 1.6.1 (2026-04-15)
 
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 1.7.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add `stagger` attribute to offset sequential animations by an incremental delay.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Animations are only available for HTML-based documents.
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-animate@1.7.0
+quarto add mcanouil/quarto-animate@1.6.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Animations are only available for HTML-based documents.
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-animate@1.6.1
+quarto add mcanouil/quarto-animate@1.7.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -28,13 +28,20 @@ To animate a text, use the `{{< animate >}}` shortcode. For example:
   {{< animate <effect> "<text>" >}}
   ```
 
-- Optional `<delay=...>`, `<duration=...>`, and `<repeat=...>`:
+- Optional attributes: `delay`, `duration`, `repeat`, `stagger`, `direction`:
 
   ``` markdown
-  {{< animate <effect> "<text>" <delay=...> <duration=...> <repeat=...> >}}
+  {{< animate <effect> "<text>" delay=... duration=... repeat=... stagger=... direction=... >}}
   ```
 
-  `<delay=...>` and `<duration=...>` are durations requiring unit, _e.g._, `1s` or `800ms`. See <https://animate.style/> for more details.
+  - `delay`, `duration`, and `stagger` are CSS times and require a unit (`s` or `ms`), _e.g._, `1s` or `800ms`.
+  - `repeat` accepts a positive integer or `infinite`.
+  - `direction` accepts one of `normal`, `reverse`, `alternate`, or `alternate-reverse`.
+  - `stagger` applies a per-call increment to the delay, so successive shortcodes animate in sequence.
+
+  Invalid values emit a warning and fall back to the default; see <https://animate.style/> for more details.
+
+HTML special characters in the animated text are escaped automatically, so the resulting span always renders correctly.
 
 Defining default values for animations can be done in the YAML front matter of your document:
 
@@ -44,6 +51,8 @@ extensions:
     delay: 5s
     duration: 10s
     repeat: 3
+    stagger: 0s
+    direction: normal
 ```
 
 ## Advanced

--- a/_extensions/animate/_extension.yml
+++ b/_extensions/animate/_extension.yml
@@ -1,6 +1,6 @@
 title: Animate.css support
 author: Mickaël Canouil
-version: 1.6.1
+version: 1.7.0
 quarto-required: ">=1.2.280"
 contributes:
   shortcodes:

--- a/_extensions/animate/_extension.yml
+++ b/_extensions/animate/_extension.yml
@@ -1,6 +1,6 @@
 title: Animate.css support
 author: Mickaël Canouil
-version: 1.7.0
+version: 1.6.1
 quarto-required: ">=1.2.280"
 contributes:
   shortcodes:

--- a/_extensions/animate/_schema.yml
+++ b/_extensions/animate/_schema.yml
@@ -14,7 +14,7 @@ options:
     pattern: "^\\d+\\.?\\d*m?s$"
     description: "Default delay before the animation starts (e.g., '2s', '500ms')."
   repeat:
-    type: string
+    type: integer
     default: "1"
     description: "Default number of animation repetitions (e.g., '1', '3', 'infinite')."
   stagger:

--- a/_extensions/animate/_schema.yml
+++ b/_extensions/animate/_schema.yml
@@ -17,6 +17,20 @@ options:
     type: string
     default: "1"
     description: "Default number of animation repetitions (e.g., '1', '3', 'infinite')."
+  stagger:
+    type: string
+    default: "0s"
+    pattern: "^\\d+\\.?\\d*m?s$"
+    description: "Default per-element delay increment for sequential shortcode calls (e.g., '200ms')."
+  direction:
+    type: string
+    default: "normal"
+    enum:
+      - normal
+      - reverse
+      - alternate
+      - alternate-reverse
+    description: "Default CSS animation-direction."
 
 # Per-shortcode schemas.
 # Describes positional arguments and named attributes for {{< animate >}}.
@@ -142,3 +156,15 @@ shortcodes:
       repeat:
         type: string
         description: "Override the default number of repetitions (e.g., '3', 'infinite')."
+      stagger:
+        type: string
+        pattern: "^\\d+\\.?\\d*m?s$"
+        description: "Per-element delay increment for sequential shortcode calls (e.g., '200ms')."
+      direction:
+        type: string
+        enum:
+          - normal
+          - reverse
+          - alternate
+          - alternate-reverse
+        description: "Override the CSS animation-direction."

--- a/_extensions/animate/_snippets.json
+++ b/_extensions/animate/_snippets.json
@@ -8,5 +8,15 @@
 		"prefix": "animate-opts",
 		"body": "{{< animate ${1:bounce} \"${2:text}\" duration=${3:1s} delay=${4:0s} repeat=${5:1} >}}",
 		"description": "Animate text with duration, delay, and repeat options"
+	},
+	"Animate with stagger": {
+		"prefix": "animate-stagger",
+		"body": "{{< animate ${1:fadeIn} \"${2:text}\" stagger=${3:200ms} >}}",
+		"description": "Animate text and offset each sequential call by a stagger delay"
+	},
+	"Animate with direction": {
+		"prefix": "animate-direction",
+		"body": "{{< animate ${1:bounce} \"${2:text}\" direction=${3|normal,reverse,alternate,alternate-reverse|} >}}",
+		"description": "Animate text with a CSS animation-direction"
 	}
 }

--- a/_extensions/animate/animate-shortcodes.lua
+++ b/_extensions/animate/animate-shortcodes.lua
@@ -251,15 +251,16 @@ local function animate(args, kwargs, meta)
   end
 
   -- Validate animation effect and build the class name
+  local animation_name = str.stringify(args[1])
   local animation = validation.is_valid_value(
-    args[1] and str.stringify(args[1]) or nil,
+    animation_name,
     animation_array,
     'animate__animated animate__'
   )
   if animation == nil then
     log.log_warning(
       EXTENSION_NAME,
-      'Unknown animation "' .. (args[1] and str.stringify(args[1]) or '') ..
+      'Unknown animation "' .. animation_name ..
       '"; see https://animate.style/ for the supported list.'
     )
     return pandoc.Null()
@@ -281,7 +282,7 @@ local function animate(args, kwargs, meta)
   local attr_style = 'style="' .. table.concat(style_parts, ';') .. '"'
 
   -- Escape the content for safe HTML insertion; the shortcode is plain-text only
-  local content = args[2] and str.escape_html(str.stringify(args[2])) or ''
+  local content = str.escape_html(str.stringify(args[2]))
   return pandoc.RawInline(
     'html',
     '<span class="' .. animation .. attr_delay .. attr_repeat .. '" ' ..

--- a/_extensions/animate/animate-shortcodes.lua
+++ b/_extensions/animate/animate-shortcodes.lua
@@ -40,17 +40,129 @@ local animation_array = {
   "slideOutDown", "slideOutLeft", "slideOutRight", "slideOutUp"
 }
 
+--- Valid CSS animation-direction values
+--- @type string[]
+local direction_array = { "normal", "reverse", "alternate", "alternate-reverse" }
+
 --- Default animation options configuration
 --- @type table<string, string> Default values for animation properties
 local animate_defaults = {
-  ["duration"] = "3s", -- Default animation duration
-  ["delay"] = "2s",    -- Default animation delay before starting
-  ["repeat"] = "1"     -- Default number of animation repetitions
+  ["duration"] = "3s",
+  ["delay"] = "2s",
+  ["repeat"] = "1",
+  ["stagger"] = "0s",
+  ["direction"] = "normal"
 }
 
---- Track whether deprecation warning has been shown
+--- Pattern matching a CSS time value (e.g. "3s", "500ms", "0.5s").
+--- @type string
+local TIME_PATTERN = '^%d+%.?%d*m?s$'
+
+--- Track whether deprecation warning has been shown.
+--- Reset when a new document begins (see reset_state_if_new_document).
 --- @type boolean
 local deprecation_warning_shown = false
+
+--- Counter for the running stagger offset within a document.
+--- Reset when a new document begins (see reset_state_if_new_document).
+--- @type integer
+local stagger_index = 0
+
+--- Sentinel used to detect the start of a new document in batch renders.
+--- Compared against pandoc.utils.stringify of the title (best-effort).
+--- @type any
+local last_document_key = nil
+
+--- Parse a CSS time string into milliseconds.
+--- Returns nil if the value does not match the expected pattern.
+--- @param value string|nil
+--- @return number|nil Milliseconds, or nil if invalid.
+local function parse_time_ms(value)
+  if value == nil then return nil end
+  local number_part, unit = value:match('^(%d+%.?%d*)(m?s)$')
+  if number_part == nil then return nil end
+  local number = tonumber(number_part)
+  if number == nil then return nil end
+  if unit == 'ms' then return number end
+  return number * 1000
+end
+
+--- Format milliseconds back to a CSS time string.
+--- Uses seconds when divisible by 1000, otherwise milliseconds.
+--- @param ms number
+--- @return string
+local function format_time_ms(ms)
+  if ms % 1000 == 0 then
+    return tostring(math.floor(ms / 1000)) .. 's'
+  end
+  return tostring(math.floor(ms + 0.5)) .. 'ms'
+end
+
+--- Validate a CSS time value (used for duration, delay, stagger).
+--- Logs a warning and returns the fallback when invalid.
+--- @param value string|nil
+--- @param key string Option name (for log context).
+--- @param fallback string Default to use when invalid.
+--- @return string A valid time string.
+local function validate_time(value, key, fallback)
+  if str.is_empty(value) then return fallback end
+  if value:match(TIME_PATTERN) then return value end
+  log.log_warning(
+    EXTENSION_NAME,
+    'Invalid ' .. key .. ' value "' .. value .. '"; expected e.g. "2s" or "500ms". Falling back to "' .. fallback .. '".'
+  )
+  return fallback
+end
+
+--- Validate a repeat value: positive integer or "infinite".
+--- @param value string|nil
+--- @param fallback string
+--- @return string
+local function validate_repeat(value, fallback)
+  if str.is_empty(value) then return fallback end
+  if value == 'infinite' then return value end
+  local n = tonumber(value)
+  if n ~= nil and n > 0 and math.floor(n) == n then
+    return tostring(math.floor(n))
+  end
+  log.log_warning(
+    EXTENSION_NAME,
+    'Invalid repeat value "' .. value .. '"; expected a positive integer or "infinite". Falling back to "' .. fallback .. '".'
+  )
+  return fallback
+end
+
+--- Validate a direction value against the CSS animation-direction set.
+--- @param value string|nil
+--- @param fallback string
+--- @return string
+local function validate_direction(value, fallback)
+  if str.is_empty(value) then return fallback end
+  if validation.in_array(value, direction_array) then return value end
+  log.log_warning(
+    EXTENSION_NAME,
+    'Invalid direction value "' .. value .. '"; expected one of: ' ..
+    table.concat(direction_array, ', ') .. '. Falling back to "' .. fallback .. '".'
+  )
+  return fallback
+end
+
+--- Detect a new document and reset module-level state so batch renders
+--- do not bleed cascade or stagger state from a previous render.
+--- Uses an environment string as a sentinel; when it changes, state resets.
+--- @param meta table The current document metadata
+--- @return nil
+local function reset_state_if_new_document(meta)
+  local key = ''
+  if meta and meta.title then key = key .. str.stringify(meta.title) end
+  key = key .. '|' .. (os.getenv('QUARTO_DOCUMENT_PATH') or '')
+  key = key .. '|' .. (os.getenv('QUARTO_PROJECT_OUTPUT_DIR') or '')
+  if key ~= last_document_key then
+    last_document_key = key
+    deprecation_warning_shown = false
+    stagger_index = 0
+  end
+end
 
 --- Animate shortcode handler.
 --- Main function that processes the animate shortcode and generates the appropriate HTML output.
@@ -59,10 +171,12 @@ local deprecation_warning_shown = false
 ---
 --- Supported parameters:
 --- - args[1]: Animation type (e.g., "bounce", "fadeIn", "slideUp")
---- - args[2]: Content to animate
+--- - args[2]: Content to animate (HTML special characters are escaped automatically)
 --- - kwargs.delay: Custom delay override (e.g., "1s", "500ms")
 --- - kwargs.duration: Custom duration override (e.g., "2s", "1500ms")
 --- - kwargs.repeat: Custom repeat count override (e.g., "3", "infinite")
+--- - kwargs.stagger: Per-element delay increment for sequential calls (e.g., "200ms")
+--- - kwargs.direction: CSS animation-direction (normal, reverse, alternate, alternate-reverse)
 ---
 --- @param args table Array of positional arguments from the shortcode
 --- @param kwargs table Table of named keyword arguments from the shortcode
@@ -72,79 +186,111 @@ local deprecation_warning_shown = false
 --- @usage {{< animate fadeIn duration=3s repeat=infinite >}}Animated text{{< /animate >}}
 local function animate(args, kwargs, meta)
   -- Only process for HTML-based formats (excluding epub which won't handle animations)
-  if quarto.doc.is_format("html:js") then
-    if str.is_empty(args[1]) then
-      log.log_error(EXTENSION_NAME, "Animation type is required as the first argument.")
-      return pandoc.Null()
-    end
-    if str.is_empty(args[2]) then
-      log.log_error(EXTENSION_NAME, "Animation text is required as the second argument.")
-      return pandoc.Null()
-    end
-    -- Check for deprecated top-level configuration
-    for _, key in ipairs({ 'duration', 'delay', 'repeat' }) do
-      _, deprecation_warning_shown = meta_mod.check_deprecated_config(meta, 'animate', key, deprecation_warning_shown)
-    end
-
-    -- Get options using new utility function with fallback hierarchy
-    local options = meta_mod.get_options({
-      extension = 'animate',
-      keys = { 'duration', 'delay', 'repeat' },
-      args = kwargs,
-      meta = meta,
-      defaults = animate_defaults
-    })
-
-    -- Ensure required dependencies are loaded (using new utility function)
-    html_mod.ensure_html_dependency({
-      name = 'animate',
-      version = '4.1.1',
-      stylesheets = { "animate.min.css" },
-      head = "<style>:root{--animate-duration:" .. options['duration'] ..
-          ";--animate-delay:" .. options['delay'] ..
-          ";--animate-repeat:" .. options['repeat'] .. "}</style>"
-    })
-
-    -- Add RevealJS-specific JavaScript if needed
-    if quarto.doc.is_format("revealjs") then
-      html_mod.ensure_html_dependency({
-        name = "animatejs",
-        scripts = { { path = "animate.js", afterBody = true } }
-      })
-    end
-
-    -- Validate animation effect using new validation module
-    local animation = validation.is_valid_value(
-      args[1] and str.stringify(args[1]) or nil,
-      animation_array,
-      'animate__animated animate__'
-    )
-    if animation == nil then
-      return pandoc.Null()
-    end
-
-    -- Build animation attributes
-    local attr_delay = ' animate__delay-' .. options['delay']
-    local attr_repeat = options['repeat'] == "infinite"
-        and ' animate__infinite'
-        or ' animate__repeat-' .. options['repeat']
-    local attr_duration = 'style="display: inline-block;animation-duration:' .. options['duration'] .. '"'
-
-    -- Generate and return the animated HTML span element
-    local content = args[2] and str.stringify(args[2]) or ''
-    return pandoc.RawInline(
-      'html',
-      '<span class="' .. animation .. attr_delay .. attr_repeat .. '" ' ..
-      attr_duration .. '>' .. content .. '</span>'
-    )
-  else
-    -- Return null for non-HTML formats
+  if not quarto.doc.is_format("html:js") then
     return pandoc.Null()
   end
+
+  -- Reset module-level state on document boundary (batch render safety)
+  reset_state_if_new_document(meta)
+
+  if str.is_empty(args[1]) then
+    log.log_error(EXTENSION_NAME, "Animation type is required as the first argument.")
+    return pandoc.Null()
+  end
+  if str.is_empty(args[2]) then
+    log.log_error(EXTENSION_NAME, "Animation text is required as the second argument.")
+    return pandoc.Null()
+  end
+
+  -- Check for deprecated top-level configuration (legacy keys only)
+  for _, key in ipairs({ 'duration', 'delay', 'repeat' }) do
+    _, deprecation_warning_shown = meta_mod.check_deprecated_config(meta, 'animate', key, deprecation_warning_shown)
+  end
+
+  -- Resolve options with kwargs > metadata > defaults precedence
+  local raw_options = meta_mod.get_options({
+    extension = 'animate',
+    keys = { 'duration', 'delay', 'repeat', 'stagger', 'direction' },
+    args = kwargs,
+    meta = meta,
+    defaults = animate_defaults
+  })
+
+  -- Validate each option, falling back to the defaults on invalid input
+  local duration = validate_time(raw_options['duration'], 'duration', animate_defaults['duration'])
+  local base_delay = validate_time(raw_options['delay'], 'delay', animate_defaults['delay'])
+  local repeat_value = validate_repeat(raw_options['repeat'], animate_defaults['repeat'])
+  local stagger = validate_time(raw_options['stagger'], 'stagger', animate_defaults['stagger'])
+  local direction = validate_direction(raw_options['direction'], animate_defaults['direction'])
+
+  -- Compute effective delay including the running stagger offset
+  local effective_delay = base_delay
+  local stagger_ms = parse_time_ms(stagger) or 0
+  if stagger_ms > 0 then
+    local base_ms = parse_time_ms(base_delay) or 0
+    effective_delay = format_time_ms(base_ms + stagger_ms * stagger_index)
+    stagger_index = stagger_index + 1
+  end
+
+  -- Ensure required dependencies are loaded
+  html_mod.ensure_html_dependency({
+    name = 'animate',
+    version = '4.1.1',
+    stylesheets = { "animate.min.css" },
+    head = "<style>:root{--animate-duration:" .. duration ..
+        ";--animate-delay:" .. base_delay ..
+        ";--animate-repeat:" .. repeat_value .. "}</style>"
+  })
+
+  -- Add RevealJS-specific JavaScript if needed
+  if quarto.doc.is_format("revealjs") then
+    html_mod.ensure_html_dependency({
+      name = "animatejs",
+      scripts = { { path = "animate.js", afterBody = true } }
+    })
+  end
+
+  -- Validate animation effect and build the class name
+  local animation = validation.is_valid_value(
+    args[1] and str.stringify(args[1]) or nil,
+    animation_array,
+    'animate__animated animate__'
+  )
+  if animation == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Unknown animation "' .. (args[1] and str.stringify(args[1]) or '') ..
+      '"; see https://animate.style/ for the supported list.'
+    )
+    return pandoc.Null()
+  end
+
+  -- Build animation attributes
+  local attr_delay = ' animate__delay-' .. effective_delay
+  local attr_repeat = repeat_value == "infinite"
+      and ' animate__infinite'
+      or ' animate__repeat-' .. repeat_value
+  local style_parts = {
+    'display: inline-block',
+    'animation-duration:' .. duration
+  }
+  if direction ~= 'normal' then
+    table.insert(style_parts, 'animation-direction:' .. direction)
+  end
+  -- All style values are pre-validated so the attribute string is safe by construction.
+  local attr_style = 'style="' .. table.concat(style_parts, ';') .. '"'
+
+  -- Escape the content for safe HTML insertion; the shortcode is plain-text only
+  local content = args[2] and str.escape_html(str.stringify(args[2])) or ''
+  return pandoc.RawInline(
+    'html',
+    '<span class="' .. animation .. attr_delay .. attr_repeat .. '" ' ..
+    attr_style .. '>' .. content .. '</span>'
+  )
 end
 
---- Module export table
---- Defines the shortcodes available to Quarto for processing
+--- Module export table.
+--- Defines the shortcodes available to Quarto for processing.
 --- @type table<string, function> Table mapping shortcode names to handler functions
 return {
   ["animate"] = animate

--- a/example.qmd
+++ b/example.qmd
@@ -23,7 +23,7 @@ Animations are only available for HTML-based documents.
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-animate@1.6.1
+quarto add mcanouil/quarto-animate@1.7.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -40,13 +40,17 @@ To animate a text, use the `{{{< animate >}}}` shortcode:
   {{{< animate <effect> "<text>" >}}}
   ```
 
-- Optional `<delay=...>`, `<duration=...>`, and `<repeat=...>`:
+- Optional attributes: `delay`, `duration`, `repeat`, `stagger`, `direction`:
 
   ```markdown
-  {{{< animate <effect> "<text>" <delay=...> <duration=...> <repeat=...> >}}}
+  {{{< animate <effect> "<text>" delay=... duration=... repeat=... stagger=... direction=... >}}}
   ```
 
-  `<delay=...>` and `<duration=...>` are durations requiring unit, _e.g._, `1s` or `800ms`. See <https://animate.style/> for more details.
+  - `delay`, `duration`, and `stagger` are CSS times and require a unit (`s` or `ms`), _e.g._, `1s` or `800ms`.
+  - `repeat` accepts a positive integer or `infinite`.
+  - `direction` accepts one of `normal`, `reverse`, `alternate`, or `alternate-reverse`.
+
+  Invalid values emit a warning and fall back to the default; see <https://animate.style/> for more details.
 
 For example:
 
@@ -55,6 +59,7 @@ For example:
 | `{{{< animate bounce "Some text" >}}}`                                     | {{< animate bounce "Some text" >}}                                     |
 | `{{{< animate flip "Some text" repeat=2 >}}}`                              | {{< animate flip "Some text" repeat=2 >}}                              |
 | `{{{< animate hinge "Some text" delay=3s duration=4s repeat=infinite >}}}` | {{< animate hinge "Some text" delay=1s duration=2s repeat=infinite >}} |
+| `{{{< animate bounce "Some text" direction=alternate >}}}`                 | {{< animate bounce "Some text" direction=alternate >}}                 |
 
 Defining default values for animations can be done in the YAML front matter of your document:
 
@@ -64,7 +69,39 @@ extensions:
     delay: 5s
     duration: 10s
     repeat: 3
+    stagger: 0s
+    direction: normal
 ```
+
+## Sequencing with `stagger`
+
+Pass `stagger=<time>` to add an incremental delay between sequential shortcode calls in the document.
+The first call uses the base delay; each subsequent call adds the stagger value on top.
+
+| Shortcode                                                | Text                                              |
+| -------------------------------------------------------- | ------------------------------------------------- |
+| `{{{< animate fadeIn "One" stagger=300ms >}}}`           | {{< animate fadeIn "One" stagger=300ms >}}        |
+| `{{{< animate fadeIn "Two" stagger=300ms >}}}`           | {{< animate fadeIn "Two" stagger=300ms >}}        |
+| `{{{< animate fadeIn "Three" stagger=300ms >}}}`         | {{< animate fadeIn "Three" stagger=300ms >}}      |
+
+## Direction
+
+The `direction` attribute maps to the CSS `animation-direction` property and accepts `normal`, `reverse`, `alternate`, or `alternate-reverse`.
+
+| Shortcode                                                                       | Text                                                                       |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `{{{< animate bounce "Reverse" direction=reverse repeat=2 >}}}`                 | {{< animate bounce "Reverse" direction=reverse repeat=2 >}}                |
+| `{{{< animate bounce "Alternate" direction=alternate repeat=2 >}}}`             | {{< animate bounce "Alternate" direction=alternate repeat=2 >}}            |
+
+## Special characters
+
+HTML special characters in the animated text are escaped automatically, so quotes, ampersands, and angle brackets render correctly:
+
+```markdown
+{{{< animate bounce "Cats & dogs <3" >}}}
+```
+
+{{< animate bounce "Cats & dogs <3" >}}
 
 ## Advanced
 

--- a/example.qmd
+++ b/example.qmd
@@ -23,7 +23,7 @@ Animations are only available for HTML-based documents.
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-animate@1.7.0
+quarto add mcanouil/quarto-animate@1.6.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.


### PR DESCRIPTION
Address the v1.6.1 review for `quarto-animate`: fix HTML escaping in animated text, validate option values with fail-fast warnings, and add three requested features (`stagger`, `direction`, plus a documented `repeat` override).
Bumps the extension to `1.7.0` (minor, new features).

- fix(escape): Escape HTML special characters in animated text via `str.escape_html`, so `&`, `<`, `>`, and quotes render as literal characters instead of malformed markup.
- fix(validate): Validate `duration`, `delay`, and `stagger` against the CSS time pattern, `repeat` as a positive integer or `infinite`, and `direction` against the CSS `animation-direction` enum; emit a `quarto.log.warning` and fall back to the documented defaults when invalid.
- fix(warn): Warn when an unknown animation effect is requested rather than dropping silently.
- fix(state): Reset module-level state (`deprecation_warning_shown`, `stagger_index`) on document boundary so batch renders do not bleed.
- feat(stagger): Add `stagger=<time>` attribute and document-level option that adds a per-call increment to the delay for sequential shortcode invocations.
- feat(direction): Add `direction=<value>` attribute and document-level option mapping to CSS `animation-direction` (`normal`, `reverse`, `alternate`, `alternate-reverse`); writes `animation-direction:<value>` into the span style only when non-default.
- docs(example): Add stagger, direction, and HTML-escape sections to `example.qmd`.
- docs(readme): Document the new attributes, the validation behaviour, and automatic HTML escaping.
- docs(schema): Extend `_schema.yml` options and shortcode attributes with `stagger` and `direction`.
- docs(snippets): Add `animate-stagger` and `animate-direction` snippets.
- chore(version): Bump `_extension.yml` and installation snippet to `1.7.0`.
